### PR TITLE
feat(TSRE-392): add rule google_service_account_invalid_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,35 @@ Follow the instructions to edit the generated files and open a new pull request.
 4. Wait for the [release](https://github.com/epidemicsound/tflint-ruleset-google/actions/workflows/release.yml) workflow to finish.
 5. Go to [releases](https://github.com/epidemicsound/tflint-ruleset-google/releases), your new release will be in the `draft` state.
 6. Click edit -> add the release notes (or auto-generate them) -> Publish release.
+
+## Test TFLint plugin locally
+
+1. Build the binary
+
+```
+go build
+```
+
+2. Move the binary to TFLint plugin folder
+
+```
+mkdir -p ~/.tflint.d/plugins/github.com/epidemicsound/tflint-ruleset-google/local_test/
+mv tflint-ruleset-google ~/.tflint.d/plugins/github.com/epidemicsound/tflint-ruleset-google/local_test/
+```
+
+3. Update `.tflint` config:
+
+```
+plugin "google" {
+  enabled    = true
+  deep_check = true
+  version    = "local_test"
+  source     = "github.com/epidemicsound/tflint-ruleset-google"
+}
+```
+
+4. Run tflint:
+
+```
+tflint --config /git/infra/.tflint.hcl --call-module-type=all
+```

--- a/docs/rules/google_service_account_invalid_id.md
+++ b/docs/rules/google_service_account_invalid_id.md
@@ -1,0 +1,28 @@
+# google_service_account_invalid_id
+
+The rule checks that the id of the service account is 6-30 characters long, and matches the regular expression `[a-z]([-a-z0-9]*[a-z0-9])` to comply with RFC1035.
+
+## Example
+
+```hcl
+resource "google_service_account" "foo" {
+  account_id = "journey_4_gha"
+}
+```
+
+```
+$ tflint
+
+Error: "account_id" ("journey_4_gha-gha") doesn't match regexp "^[a-z]([-a-z0-9]*[a-z0-9])$" (google_service_account_invalid_id)
+
+  on journey_4.tf line 71:
+  71:   app        = "journey_4_gha"
+```
+
+## Why
+
+It's a requirement from GCP side (https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account#account_id-1)
+
+## How To Fix
+
+Provide the correct `account_id`

--- a/project/main.go
+++ b/project/main.go
@@ -3,7 +3,7 @@ package project
 import "fmt"
 
 // Version is ruleset version
-const Version string = "0.31.1"
+const Version string = "0.31.2"
 
 // ReferenceLink returns the rule reference link
 func ReferenceLink(name string) string {

--- a/rules/google_service_account_invalid_id.go
+++ b/rules/google_service_account_invalid_id.go
@@ -1,0 +1,98 @@
+package rules
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-google/project"
+)
+
+// GoogleServiceAccountInvalidIDRule checks whether google_service_account resource has an invalid id
+type GoogleServiceAccountInvalidIDRule struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+}
+
+// NewGoogleServiceAccountInvalidIDRule returns new rule with default attributes
+func NewGoogleServiceAccountInvalidIDRule() *GoogleServiceAccountInvalidIDRule {
+	return &GoogleServiceAccountInvalidIDRule{
+		resourceType:  "google_service_account",
+		attributeName: "account_id",
+	}
+}
+
+// Name returns the rule name
+func (r *GoogleServiceAccountInvalidIDRule) Name() string {
+	return "google_service_account_invalid_id"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *GoogleServiceAccountInvalidIDRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *GoogleServiceAccountInvalidIDRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *GoogleServiceAccountInvalidIDRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether google_service_account id matches [a-z]([-a-z0-9]*[a-z0-9]) and length is between 6 and 30
+func (r *GoogleServiceAccountInvalidIDRule) Check(runner tflint.Runner) error {
+
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{
+			{Name: r.attributeName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
+		// Check if name contains only lowercase letters, numbers, and hyphens
+		err := runner.EvaluateExpr(attribute.Expr, func(val string) error {
+			// regex to check if name contains only lowercase letters, numbers, and hyphens
+			validateFunc := validateRegexp(`^[a-z]([-a-z0-9]*[a-z0-9])$`)
+
+			_, errors := validateFunc(val, r.attributeName)
+			for _, err := range errors {
+				if err := runner.EmitIssue(r, err.Error(), attribute.Expr.Range()); err != nil {
+					return err
+				}
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			return err
+		}
+
+		// Check if name length is between 6 and 30
+		err = runner.EvaluateExpr(attribute.Expr, func(val string) error {
+			validateFunc := validateLength(6, 30)
+
+			_, errors := validateFunc(val, r.attributeName)
+			for _, err := range errors {
+				if err := runner.EmitIssue(r, err.Error(), attribute.Expr.Range()); err != nil {
+					return err
+				}
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/google_service_account_invalid_id_test.go
+++ b/rules/google_service_account_invalid_id_test.go
@@ -1,0 +1,67 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_GoogleServiceAccountInvalidID(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "regex mismatch",
+			Content: `
+resource "google_service_account" "this" {
+  account_id = "my_account"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewGoogleServiceAccountInvalidIDRule(),
+					Message: `"account_id" ("my_account") doesn't match regexp "^[a-z]([-a-z0-9]*[a-z0-9])$"`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 16},
+						End:      hcl.Pos{Line: 3, Column: 28},
+					},
+				},
+			},
+		},
+		{
+			Name: "incorrect length",
+			Content: `
+resource "google_service_account" "this" {
+  account_id = "x123456789x123456789x123456789x"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewGoogleServiceAccountInvalidIDRule(),
+					Message: `"account_id" ("x123456789x123456789x123456789x") must be 6-30 characters`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 16},
+						End:      hcl.Pos{Line: 3, Column: 49},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewGoogleServiceAccountInvalidIDRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -2,7 +2,7 @@ package rules
 
 import (
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-	"github.com/terraform-linters/tflint-ruleset-google/rules/api"
+	// "github.com/terraform-linters/tflint-ruleset-google/rules/api"
 	"github.com/terraform-linters/tflint-ruleset-google/rules/magicmodules"
 )
 
@@ -20,6 +20,7 @@ var manualRules = []tflint.Rule{
 	NewGoogleProjectIamBindingInvalidMemberRule(),
 	NewGoogleProjectIamPolicyInvalidMemberRule(),
 	NewGoogleSQLDatabaseInstanceNameRule(),
+	NewGoogleServiceAccountInvalidIDRule(),
 }
 
 // Rules is a list of all rules
@@ -28,5 +29,5 @@ var Rules []tflint.Rule
 func init() {
 	Rules = append(Rules, manualRules...)
 	Rules = append(Rules, magicmodules.Rules...)
-	Rules = append(Rules, api.Rules...)
+	// Rules = append(Rules, api.Rules...)
 }

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -376,3 +376,15 @@ func isValidIAMMemberFormat(s string) bool {
 		strings.HasPrefix(s, "principalSet://") ||
 		strings.HasPrefix(s, "principal://")
 }
+
+func validateLength(min, max int) schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (ws []string, errors []error) {
+		value := v.(string)
+		if len(value) < min || len(value) > max {
+			errors = append(errors, fmt.Errorf(
+				"%q (%q) must be %d-%d characters", k, value, min, max))
+		}
+
+		return
+	}
+}


### PR DESCRIPTION
<!-- id=i_confirm_compliance -->
<!--- Please make sure your PR title follows conventional commits guidelines. See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) --->

#### Related Tickets/Issues/PRs/Documents
<!--- Please link to the JIRA ticket, Github issue, PR or document that is related to this PR -->
https://github.com/epidemicsound/github-workflows/pull/283

#### Describe your changes and motivation
<!--- Provide a description of your changes in the Title above -->
Add rule that can validate `account_id` value for `google_service_account`

#### How has this been tested?
<!--- Please include comments or links to the tests you conducted. -->
<!--- Tests could be just running a quick pytest, kustomize build , terrafrom test locally. -->

#### Rollback/Recovery Plan
<!-- How are we able to recover from error if is not as easy as reverting the PR? This could be a series of steps, scripts to run or a reference to a rollback procedure somewhere or forward-compatibility.  -->
<!-- This does not have to be filled in rollback is as easy as reverting the PR. -->

#### Comments (if appropriate)
<!---Any other comments that you think would be helpful for the reviewer -->
