### PR TITLE
fix(TSRE-392): add rules/google_pubsub_subscription_expiration_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can install the plugin by adding a config to `.tflint.hcl` and running `tfli
 ```hcl
 plugin "google" {
     enabled = true
-    version = "0.31.1"
+    version = "0.31.3"
     source  = "github.com/epidemicsound/tflint-ruleset-google"
 }
 ```

--- a/docs/rules/google_pubsub_subscription_expiration_policy.md
+++ b/docs/rules/google_pubsub_subscription_expiration_policy.md
@@ -1,0 +1,33 @@
+# google_pubsub_subscription_expiration_policy
+
+By default if no expiration policy is set to pubsub subscriptions, they expire after 31 days with no activity.
+We recommend setting this value explicitly to avoid confusion in the future.
+
+## Example
+
+```hcl
+resource "google_pubsub_subscription" "this" {
+  name  = "this-subscription"
+  topic = "this-topic"
+}
+```
+
+```
+$ tflint
+
+Error: set expiration_policy explicitly or disable it with "ttl = ''", otherwise it defaults to 31 days (google_pubsub_subscription_expiration_policy)
+
+  on this.tf line 21:
+ 291: resource "google_pubsub_subscription" "this" {
+
+Reference: https://github.com/epidemicsound/tflint-ruleset-google/blob/v0.31.2/docs/rules/google_pubsub_subscription_expiration_policy.md
+
+```
+
+## Why
+
+It's not clear that the default `ttl` is 31 days if the value is unset. We enforce the setting to be set explicitly to avoid confusion in the future.
+
+## How To Fix
+
+Set the `expiration_policy`.

--- a/project/main.go
+++ b/project/main.go
@@ -3,7 +3,7 @@ package project
 import "fmt"
 
 // Version is ruleset version
-const Version string = "0.31.2"
+const Version string = "0.31.3"
 
 // ReferenceLink returns the rule reference link
 func ReferenceLink(name string) string {

--- a/rules/google_pubsub_subscription_expiration_policy.go
+++ b/rules/google_pubsub_subscription_expiration_policy.go
@@ -1,0 +1,79 @@
+package rules
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-google/project"
+)
+
+// GooglePubsubSubscriptionExpirationPolicyRule checks if expiration_policy is set in google_pubsub_subscription
+type GooglePubsubSubscriptionExpirationPolicyRule struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+}
+
+// NewGooglePubsubSubscriptionExpirationPolicyRule returns new rule with default attributes
+func NewGooglePubsubSubscriptionExpirationPolicyRule() *GooglePubsubSubscriptionExpirationPolicyRule {
+	return &GooglePubsubSubscriptionExpirationPolicyRule{
+		resourceType:  "google_pubsub_subscription",
+		attributeName: "expiration_policy",
+	}
+}
+
+// Name returns the rule name
+func (r *GooglePubsubSubscriptionExpirationPolicyRule) Name() string {
+	return "google_pubsub_subscription_expiration_policy"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *GooglePubsubSubscriptionExpirationPolicyRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *GooglePubsubSubscriptionExpirationPolicyRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *GooglePubsubSubscriptionExpirationPolicyRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Throw error if expiration_policy is missing in google_pubsub_subscription
+func (r *GooglePubsubSubscriptionExpirationPolicyRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{Type: r.attributeName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		expirationPolicyExists := false
+
+		// Iterate over blocks to check if "expiration_policy" exists
+		for _, block := range resource.Body.Blocks {
+			if block.Type == r.attributeName {
+				expirationPolicyExists = true
+				break
+			}
+		}
+
+		if !expirationPolicyExists {
+			if err := runner.EmitIssue(
+				r,
+				"set expiration_policy explicitly or disable it with \"ttl = ''\", otherwise it defaults to 31 days",
+				resource.DefRange,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/rules/google_pubsub_subscription_expiration_policy_test.go
+++ b/rules/google_pubsub_subscription_expiration_policy_test.go
@@ -1,0 +1,115 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_GooglePubsubSubscriptionExpirationPolicy(t *testing.T) {
+	rule := NewGooglePubsubSubscriptionExpirationPolicyRule()
+
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		// Missing expiration_policy block, should trigger an issue
+		{
+			Name: "no_expiration_policy",
+			Content: `
+resource "google_pubsub_subscription" "this" {
+  name  = "this-subscription"
+  topic = "this-topic"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule: rule,
+					Message: "set expiration_policy explicitly or disable it with \"ttl = ''\", otherwise it defaults to 31 days",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 45},
+					},
+				},
+			},
+		},
+
+		// expiration_policy block is present, no issue should be triggered
+		{
+			Name: "valid_expiration_policy_with_ttl",
+			Content: `
+resource "google_pubsub_subscription" "valid" {
+  name  = "valid-subscription"
+  topic = "valid-topic"
+
+  expiration_policy {
+    ttl = "3600s"
+  }
+}
+`,
+			Expected: helper.Issues{},
+		},
+
+		// explicitly disabling expiration_policy, no issue should be triggered
+		{
+			Name: "valid_expiration_policy_disabled",
+			Content: `
+resource "google_pubsub_subscription" "disabled" {
+  name  = "disabled-subscription"
+  topic = "disabled-topic"
+
+  expiration_policy {
+    ttl = ""
+  }
+}
+`,
+			Expected: helper.Issues{},
+		},
+
+		// multiple resources, 2nd one is missing expiration_policy, should trigger an issue
+		{
+			Name: "mixed_valid_invalid_resources",
+			Content: `
+resource "google_pubsub_subscription" "valid" {
+  name  = "valid-subscription"
+  topic = "valid-topic"
+
+  expiration_policy {
+    ttl = "3600s"
+  }
+}
+
+resource "google_pubsub_subscription" "invalid" {
+  name  = "invalid-subscription"
+  topic = "invalid-topic"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule: rule,
+					Message: "set expiration_policy explicitly or disable it with \"ttl = ''\", otherwise it defaults to 31 days",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 11, Column: 1},
+						End:      hcl.Pos{Line: 11, Column: 48},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -21,6 +21,7 @@ var manualRules = []tflint.Rule{
 	NewGoogleProjectIamPolicyInvalidMemberRule(),
 	NewGoogleSQLDatabaseInstanceNameRule(),
 	NewGoogleServiceAccountInvalidIDRule(),
+	NewGooglePubsubSubscriptionExpirationPolicyRule(),
 }
 
 // Rules is a list of all rules


### PR DESCRIPTION
<!-- id=i_confirm_compliance -->
<!--- Please make sure your PR title follows conventional commits guidelines. See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) --->

#### Related Tickets/Issues/PRs/Documents
<!--- Please link to the JIRA ticket, Github issue, PR or document that is related to this PR -->

#### Describe your changes and motivation
<!--- Provide a description of your changes in the Title above -->
By default if no expiration policy is set to pubsub subscriptions they expire after 31 days if there is no activity.
People should set the value explicitly or disable the default behaviour.

#### How has this been tested?
<!--- Please include comments or links to the tests you conducted. -->
<!--- Tests could be just running a quick pytest, kustomize build , terrafrom test locally. -->
Tested the TFLint behaviour locally + added the unit tests.

#### Rollback/Recovery Plan
<!-- How are we able to recover from error if is not as easy as reverting the PR? This could be a series of steps, scripts to run or a reference to a rollback procedure somewhere or forward-compatibility.  -->
<!-- This does not have to be filled in rollback is as easy as reverting the PR. -->

#### Comments (if appropriate)
<!---Any other comments that you think would be helpful for the reviewer -->
